### PR TITLE
Release/2.4.2308

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Signing material — never commit
+ergosigningkey
+encrypted_key.zip
+encryption_public_key.pem
+pepk.jar
+gradle/verification-metadata.xml.bak

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "org.ergoplatform.android"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 2308
-        versionName "2.4.2308"
+        versionCode 2310
+        versionName "2.4.2310"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "org.ergoplatform.android"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 2312
-        versionName "2.4.2312"
+        versionCode 2313
+        versionName "2.4.2313"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "org.ergoplatform.android"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 2311
-        versionName "2.4.2311"
+        versionCode 2312
+        versionName "2.4.2312"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "org.ergoplatform.android"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 2310
-        versionName "2.4.2310"
+        versionCode 2311
+        versionName "2.4.2311"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/src/main/java/org/ergoplatform/android/MainActivity.kt
+++ b/android/src/main/java/org/ergoplatform/android/MainActivity.kt
@@ -78,9 +78,15 @@ class MainActivity : AppCompatActivity() {
         // Edge-to-edge is enforced from Android 15 (targetSdk 35), so the window draws
         // behind the status bar and gesture/navigation bar. Apply system bar insets as
         // padding on the chrome views so content does not overlap with them.
+        //
+        // The nav_host_fragment is anchored to the top of the parent (not below the
+        // toolbar), so each fragment's own top header draws at y=0 and overlaps the
+        // status bar unless we add the top inset to the host container too.
         val toolbar = findViewById<View>(R.id.toolbar)
+        val navHostFragmentView = findViewById<View>(R.id.nav_host_fragment)
         val lockedView = findViewById<View>(R.id.layout_app_locked)
         val toolbarBasePaddingTop = toolbar.paddingTop
+        val navHostBasePaddingTop = navHostFragmentView.paddingTop
         val navViewBasePaddingBottom = navView.paddingBottom
         val lockedBasePaddingTop = lockedView.paddingTop
         val lockedBasePaddingBottom = lockedView.paddingBottom
@@ -90,6 +96,7 @@ class MainActivity : AppCompatActivity() {
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
             toolbar.updatePadding(top = toolbarBasePaddingTop + bars.top)
+            navHostFragmentView.updatePadding(top = navHostBasePaddingTop + bars.top)
             navView.updatePadding(bottom = navViewBasePaddingBottom + bars.bottom)
             lockedView.updatePadding(
                 top = lockedBasePaddingTop + bars.top,

--- a/android/src/main/java/org/ergoplatform/android/MainActivity.kt
+++ b/android/src/main/java/org/ergoplatform/android/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
         val lockedBasePaddingTop = lockedView.paddingTop
         val lockedBasePaddingBottom = lockedView.paddingBottom
 
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.container)) { _, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
@@ -103,6 +103,7 @@ class MainActivity : AppCompatActivity() {
 
             insets
         }
+        ViewCompat.requestApplyInsets(window.decorView)
 
         if (savedInstanceState == null) {
             handleIntent(navController)

--- a/android/src/main/java/org/ergoplatform/android/MainActivity.kt
+++ b/android/src/main/java/org/ergoplatform/android/MainActivity.kt
@@ -8,7 +8,9 @@ import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricPrompt
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -73,13 +75,33 @@ class MainActivity : AppCompatActivity() {
         }
 
 
-        // check if soft keyboard is open and hide bottom nav bar
-        window.decorView.setOnApplyWindowInsetsListener { view, insets ->
-            val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets, view)
-            val isOpen = insetsCompat.isVisible(WindowInsetsCompat.Type.ime())
-            navView.visibility = if (isOpen) View.GONE else View.VISIBLE
-            _keyboardStateFlow.value = isOpen
-            view.onApplyWindowInsets(insets)
+        // Edge-to-edge is enforced from Android 15 (targetSdk 35), so the window draws
+        // behind the status bar and gesture/navigation bar. Apply system bar insets as
+        // padding on the chrome views so content does not overlap with them.
+        val toolbar = findViewById<View>(R.id.toolbar)
+        val lockedView = findViewById<View>(R.id.layout_app_locked)
+        val toolbarBasePaddingTop = toolbar.paddingTop
+        val navViewBasePaddingBottom = navView.paddingBottom
+        val lockedBasePaddingTop = lockedView.paddingTop
+        val lockedBasePaddingBottom = lockedView.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.container)) { _, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            toolbar.updatePadding(top = toolbarBasePaddingTop + bars.top)
+            navView.updatePadding(bottom = navViewBasePaddingBottom + bars.bottom)
+            lockedView.updatePadding(
+                top = lockedBasePaddingTop + bars.top,
+                bottom = lockedBasePaddingBottom + bars.bottom,
+            )
+
+            // hide bottom nav bar while soft keyboard is open
+            val isImeOpen = insets.isVisible(WindowInsetsCompat.Type.ime())
+            navView.visibility = if (isImeOpen) View.GONE else View.VISIBLE
+            _keyboardStateFlow.value = isImeOpen
+
+            insets
         }
 
         if (savedInstanceState == null) {

--- a/android/src/main/java/org/ergoplatform/android/ui/QrScannerActivity.kt
+++ b/android/src/main/java/org/ergoplatform/android/ui/QrScannerActivity.kt
@@ -5,6 +5,9 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.view.View
 import android.widget.ImageView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.Result
@@ -19,8 +22,20 @@ class QrScannerActivity : CaptureActivity() {
     override fun initializeContent(): DecoratedBarcodeView {
         setContentView(R.layout.qrscanner_activity)
 
-        findViewById<ImageView>(R.id.paste_button).setOnClickListener {
+        val pasteButton = findViewById<ImageView>(R.id.paste_button)
+        pasteButton.setOnClickListener {
             pasteFromClipboard()
+        }
+
+        // Edge-to-edge from Android 15 (targetSdk 35) makes the status bar transparent,
+        // so add the top system bar inset to the paste button so it does not overlap.
+        val pasteBasePaddingTop = pasteButton.paddingTop
+        ViewCompat.setOnApplyWindowInsetsListener(pasteButton) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            v.updatePadding(top = pasteBasePaddingTop + bars.top)
+            insets
         }
 
         return (findViewById<View>(R.id.zxing_barcode_scanner) as DecoratedBarcodeView)

--- a/android/src/main/res/layout/activity_main.xml
+++ b/android/src/main/res/layout/activity_main.xml
@@ -24,6 +24,7 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:background="?attr/colorSurface"
         app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@id/nav_view"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -35,6 +36,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
         app:layout_constraintTop_toTopOf="parent"
         app:titleTextColor="@android:color/transparent" />
 

--- a/android/src/main/res/layout/fragment_add_wallet_chooser.xml
+++ b/android/src/main/res/layout/fragment_add_wallet_chooser.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"
+    android:fitsSystemWindows="true"
     tools:context=".wallet.AddWalletChooserFragmentDialog">
 
     <LinearLayout


### PR DESCRIPTION
## Fixes

- **Android 15 (target SDK 35) status bar overlap.** On devices running Android 15 (and forward-compatible with future versions), the wallet header, screen titles, QR scanner controls, and app-lock overlay were drawing underneath the transparent status bar / camera punch-hole, and the bottom navigation bar was being clipped by the gesture handle. The app now applies system-bar and display-cutout insets to its main chrome so content sits cleanly between the status bar and gesture nav.

## Under the hood

- Inset listener installed on the activity's window decor view (upstream of AppCompat's content frame, which was silently swallowing the insets).
- `nav_host_fragment` padded by the top inset so every fragment's own header (wallet, settings, mosaik, app overview, send funds, etc.) clears the status bar without per-fragment changes.
- Nav-host background set to `colorSurface` and toolbar background made transparent so the inset area visually blends with each screen's title bar instead of leaving a visible empty band.
- QR scanner paste button padded so it clears the status bar.
- `fitsSystemWindows` added to the add-wallet chooser dialog for parity with the other full-screen dialogs.

## No behavior change on older Android

System bars are still opaque on Android 14 and below, so reported insets are zero and the UI renders identically to 2.4.2308.

## Compatibility

- Minimum SDK: 24 (Android 7.0) — unchanged
- Target SDK: 35 (Android 15)
- No new permissions, no dependency changes