### PR TITLE
Retry signed transaction broadcasts across known nodes

### DIFF
--- a/common-jvm/src/main/java/org/ergoplatform/ErgoFacade.kt
+++ b/common-jvm/src/main/java/org/ergoplatform/ErgoFacade.kt
@@ -19,6 +19,7 @@ import org.ergoplatform.wallet.secrets.ExtendedPublicKey
 import scala.collection.JavaConversions
 import sigmastate.interpreter.HintsBag
 import sigmastate.serialization.`SigmaSerializer$`
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.util.HashMap
 import kotlin.math.max
@@ -435,16 +436,22 @@ object ErgoFacade {
     }
 
     private fun getRestErgoClient(prefs: PreferencesProvider): ErgoClient {
-        val nodeToConnectTo = prefs.prefNodeUrl
-        val ergoClient = RestApiErgoClient.createWithHttpClientBuilder(
-            nodeToConnectTo,
+        val ergoClient = createRestErgoClient(prefs.prefNodeUrl, prefs)
+        refreshNodeListWhenNeeded(prefs)
+        return ergoClient
+    }
+
+    private fun createRestErgoClient(
+        nodeUrl: String,
+        prefs: PreferencesProvider
+    ): ErgoClient {
+        return RestApiErgoClient.createWithHttpClientBuilder(
+            nodeUrl,
             getErgoNetworkType(),
             "",
             prefs.prefExplorerApiUrl,
             OkHttpSingleton.getInstance().newBuilder()
         )
-        refreshNodeListWhenNeeded(prefs)
-        return ergoClient
     }
 
     private fun refreshNodeListWhenNeeded(prefs: PreferencesProvider) {
@@ -486,14 +493,20 @@ object ErgoFacade {
         texts: StringProvider
     ): SendTransactionResult {
         try {
-            val ergoClient = getRestErgoClient(prefs)
-            return ergoClient.execute { ctx ->
-                prefs.lastBlockHeight = ctx.height.toLong()
-                val signedTx = ctx.parseSignedTransaction(signedTxSerialized)
-                val txId = ctx.sendTransaction(signedTx).trim('"')
-                SendTransactionResult(txId.isNotEmpty(), txId, signedTx)
-            }
+            refreshNodeListWhenNeeded(prefs)
+            val nodeUrls = buildNodeFallbackList(prefs.prefNodeUrl, prefs.knownNodesList)
 
+            return executeWithNodeFallback(nodeUrls) { nodeUrl ->
+                createRestErgoClient(nodeUrl, prefs).execute { ctx ->
+                    prefs.lastBlockHeight = ctx.height.toLong()
+                    val signedTx = ctx.parseSignedTransaction(signedTxSerialized)
+                    val txId = ctx.sendTransaction(signedTx).trim('"')
+                    if (txId.isEmpty()) {
+                        throw IOException("Node $nodeUrl returned an empty transaction ID")
+                    }
+                    SendTransactionResult(true, txId, signedTx)
+                }
+            }
         } catch (t: Throwable) {
             return SendTransactionResult(false, errorMsg = getErrorMessage(t, texts))
         }

--- a/common-jvm/src/main/java/org/ergoplatform/NodeFallback.kt
+++ b/common-jvm/src/main/java/org/ergoplatform/NodeFallback.kt
@@ -1,0 +1,46 @@
+package org.ergoplatform
+
+import java.io.IOException
+
+internal fun buildNodeFallbackList(
+    preferredNodeUrl: String,
+    knownNodeUrls: List<String>
+): List<String> {
+    return (listOf(preferredNodeUrl) + knownNodeUrls)
+        .mapNotNull { nodeUrl ->
+            nodeUrl.trim().trimEnd('/').takeIf { it.isNotEmpty() }?.plus('/')
+        }
+        .distinct()
+}
+
+internal fun <T> executeWithNodeFallback(
+    nodeUrls: List<String>,
+    action: (String) -> T
+): T {
+    require(nodeUrls.isNotEmpty()) { "At least one node URL is required" }
+
+    var lastFailure: Throwable? = null
+    nodeUrls.forEach { nodeUrl ->
+        try {
+            return action(nodeUrl)
+        } catch (failure: Throwable) {
+            if (!failure.isCausedByConnectionError()) {
+                throw failure
+            }
+            lastFailure = failure
+        }
+    }
+
+    throw checkNotNull(lastFailure)
+}
+
+private fun Throwable.isCausedByConnectionError(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is IOException) {
+            return true
+        }
+        current = current.cause
+    }
+    return false
+}

--- a/common-jvm/src/test/java/org/ergoplatform/NodeFallbackTest.kt
+++ b/common-jvm/src/test/java/org/ergoplatform/NodeFallbackTest.kt
@@ -1,0 +1,96 @@
+package org.ergoplatform
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+
+class NodeFallbackTest {
+
+    @Test
+    fun `preferred node is first and equivalent URLs are de-duplicated`() {
+        assertEquals(
+            listOf(
+                "https://preferred.example/",
+                "https://backup-one.example/",
+                "https://backup-two.example/"
+            ),
+            buildNodeFallbackList(
+                "https://preferred.example/",
+                listOf(
+                    "https://backup-one.example",
+                    "https://preferred.example",
+                    " ",
+                    "https://backup-two.example///"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `preferred node success does not contact fallbacks`() {
+        val attemptedNodes = mutableListOf<String>()
+
+        val result = executeWithNodeFallback(
+            listOf("preferred", "backup")
+        ) { nodeUrl ->
+            attemptedNodes.add(nodeUrl)
+            "transaction-id"
+        }
+
+        assertEquals("transaction-id", result)
+        assertEquals(listOf("preferred"), attemptedNodes)
+    }
+
+    @Test
+    fun `connection failure tries the next node`() {
+        val attemptedNodes = mutableListOf<String>()
+
+        val result = executeWithNodeFallback(
+            listOf("preferred", "backup")
+        ) { nodeUrl ->
+            attemptedNodes.add(nodeUrl)
+            if (nodeUrl == "preferred") {
+                throw IllegalStateException("request failed", IOException("connection refused"))
+            }
+            "transaction-id"
+        }
+
+        assertEquals("transaction-id", result)
+        assertEquals(listOf("preferred", "backup"), attemptedNodes)
+    }
+
+    @Test
+    fun `last connection failure is preserved when every node fails`() {
+        val preferredFailure = IOException("preferred unavailable")
+        val backupFailure = IOException("backup unavailable")
+
+        try {
+            executeWithNodeFallback<String>(listOf("preferred", "backup")) { nodeUrl ->
+                throw if (nodeUrl == "preferred") preferredFailure else backupFailure
+            }
+            fail("Expected the last node failure")
+        } catch (actual: Throwable) {
+            assertSame(backupFailure, actual)
+        }
+    }
+
+    @Test
+    fun `transaction rejection does not retry another node`() {
+        val attemptedNodes = mutableListOf<String>()
+        val rejection = IllegalStateException("transaction rejected")
+
+        try {
+            executeWithNodeFallback<String>(listOf("preferred", "backup")) { nodeUrl ->
+                attemptedNodes.add(nodeUrl)
+                throw rejection
+            }
+            fail("Expected the transaction rejection")
+        } catch (actual: Throwable) {
+            assertSame(rejection, actual)
+        }
+
+        assertEquals(listOf("preferred"), attemptedNodes)
+    }
+}


### PR DESCRIPTION
## Summary

- broadcast an already-signed transaction through the preferred node followed by the known-node list
- normalize and de-duplicate node URLs, stopping as soon as a node returns a transaction ID
- retry connection-caused failures while returning definitive transaction rejections immediately and preserving the final node error

Signing and transaction construction remain outside the retry loop, so every attempt submits the same serialized signed transaction.

## Tests

- `./gradlew common-jvm:test --tests org.ergoplatform.NodeFallbackTest --no-daemon` (5 passed)
- `./gradlew android:assembleErgomainnetDebug --no-daemon`
- `./gradlew ios:compileKotlin desktop:jar --no-daemon`
- `./gradlew common-jvm:test --no-daemon` (24 passed; the existing `ErgoPaySigningUiLogicTest.testDynamic` and `testDynamicWithoutWallet` failures reproduce unchanged on `origin/develop`)

Closes #186