### PR TITLE
Remove deprecated Compose compiler override

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,6 @@ android {
 
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion kotlin_version
     }
 }
 


### PR DESCRIPTION
Closes #185

## Summary
- remove the deprecated `kotlinCompilerVersion` override from the Android Compose configuration
- keep `kotlinCompilerExtensionVersion` unchanged
- let Compose use the Kotlin Gradle plugin version already defined in the root buildscript

## Validation
- reproduced the original warning with Java 17 before the change
- ran `./gradlew :android:tasks --warning-mode=all --console=plain` after the change: **BUILD SUCCESSFUL**, with no `ComposeOptions.kotlinCompilerVersion is deprecated` warning
- `git diff --check` passes

A full Android source compile was not run locally because no Android SDK is installed on this machine; the Gradle configuration path that emitted the warning was verified successfully.