### PR TITLE
Retry signed transaction broadcast across known nodes

### DIFF
--- a/common-jvm/src/main/java/org/ergoplatform/ErgoFacade.kt
+++ b/common-jvm/src/main/java/org/ergoplatform/ErgoFacade.kt
@@ -33,6 +33,31 @@ const val URL_FORGOT_PASSWORD_HELP =
 const val ERG_BASE_COST = 0
 private const val MAX_NUM_INPUT_BOXES = 100
 
+internal fun buildNodeBroadcastSequence(
+    preferredNodeUrl: String,
+    knownNodeUrls: List<String>
+): List<String> = (listOf(preferredNodeUrl) + knownNodeUrls)
+    .map { it.trim().trimEnd('/') }
+    .filter { it.isNotEmpty() }
+    .distinct()
+
+internal fun <T> sendToFirstAvailableNode(
+    nodeUrls: List<String>,
+    send: (String) -> T
+): T {
+    var lastFailure: Exception? = null
+
+    nodeUrls.forEach { nodeUrl ->
+        try {
+            return send(nodeUrl)
+        } catch (e: Exception) {
+            lastFailure = e
+        }
+    }
+
+    throw lastFailure ?: IllegalStateException("No node URL configured")
+}
+
 var isErgoMainNet: Boolean = true
 
 fun isValidErgoAddress(addressString: String): Boolean {
@@ -435,17 +460,21 @@ object ErgoFacade {
     }
 
     private fun getRestErgoClient(prefs: PreferencesProvider): ErgoClient {
-        val nodeToConnectTo = prefs.prefNodeUrl
-        val ergoClient = RestApiErgoClient.createWithHttpClientBuilder(
-            nodeToConnectTo,
-            getErgoNetworkType(),
-            "",
-            prefs.prefExplorerApiUrl,
-            OkHttpSingleton.getInstance().newBuilder()
-        )
+        val ergoClient = getRestErgoClient(prefs.prefNodeUrl, prefs)
         refreshNodeListWhenNeeded(prefs)
         return ergoClient
     }
+
+    private fun getRestErgoClient(
+        nodeToConnectTo: String,
+        prefs: PreferencesProvider
+    ): ErgoClient = RestApiErgoClient.createWithHttpClientBuilder(
+        nodeToConnectTo,
+        getErgoNetworkType(),
+        "",
+        prefs.prefExplorerApiUrl,
+        OkHttpSingleton.getInstance().newBuilder()
+    )
 
     private fun refreshNodeListWhenNeeded(prefs: PreferencesProvider) {
         if (System.currentTimeMillis() - prefs.lastNodeListRefreshMs > 1000L * 60 * 60 * 24) {
@@ -486,14 +515,20 @@ object ErgoFacade {
         texts: StringProvider
     ): SendTransactionResult {
         try {
-            val ergoClient = getRestErgoClient(prefs)
-            return ergoClient.execute { ctx ->
-                prefs.lastBlockHeight = ctx.height.toLong()
-                val signedTx = ctx.parseSignedTransaction(signedTxSerialized)
-                val txId = ctx.sendTransaction(signedTx).trim('"')
-                SendTransactionResult(txId.isNotEmpty(), txId, signedTx)
-            }
+            refreshNodeListWhenNeeded(prefs)
+            val nodeUrls = buildNodeBroadcastSequence(prefs.prefNodeUrl, prefs.knownNodesList)
 
+            return sendToFirstAvailableNode(nodeUrls) { nodeUrl ->
+                val ergoClient = getRestErgoClient(nodeUrl, prefs)
+                ergoClient.execute { ctx ->
+                    prefs.lastBlockHeight = ctx.height.toLong()
+                    val signedTx = ctx.parseSignedTransaction(signedTxSerialized)
+                    val txId = ctx.sendTransaction(signedTx).trim('"')
+                    if (txId.isEmpty())
+                        throw IllegalStateException("Node returned an empty transaction id")
+                    SendTransactionResult(true, txId, signedTx)
+                }
+            }
         } catch (t: Throwable) {
             return SendTransactionResult(false, errorMsg = getErrorMessage(t, texts))
         }

--- a/common-jvm/src/test/java/org/ergoplatform/ErgoFacadeNodeRetryTest.kt
+++ b/common-jvm/src/test/java/org/ergoplatform/ErgoFacadeNodeRetryTest.kt
@@ -1,0 +1,60 @@
+package org.ergoplatform
+
+import junit.framework.TestCase
+
+class ErgoFacadeNodeRetryTest : TestCase() {
+
+    fun testBuildNodeBroadcastSequenceKeepsPreferredFirstAndDeduplicates() {
+        assertEquals(
+            listOf("https://preferred.example", "https://fallback.example"),
+            buildNodeBroadcastSequence(
+                " https://preferred.example/ ",
+                listOf(
+                    "https://preferred.example",
+                    "https://fallback.example/",
+                    "",
+                    "https://fallback.example"
+                )
+            )
+        )
+    }
+
+    fun testSendToFirstAvailableNodeFallsBackInOrder() {
+        val attemptedNodes = mutableListOf<String>()
+
+        val result = sendToFirstAvailableNode(listOf("preferred", "fallback", "unused")) {
+            attemptedNodes.add(it)
+            if (it == "preferred") throw IllegalStateException("unavailable")
+            "tx-id"
+        }
+
+        assertEquals("tx-id", result)
+        assertEquals(listOf("preferred", "fallback"), attemptedNodes)
+    }
+
+    fun testSendToFirstAvailableNodeStopsAfterPreferredSucceeds() {
+        val attemptedNodes = mutableListOf<String>()
+
+        val result = sendToFirstAvailableNode(listOf("preferred", "fallback")) {
+            attemptedNodes.add(it)
+            "tx-id"
+        }
+
+        assertEquals("tx-id", result)
+        assertEquals(listOf("preferred"), attemptedNodes)
+    }
+
+    fun testSendToFirstAvailableNodeRethrowsLastFailure() {
+        val firstFailure = IllegalStateException("first")
+        val lastFailure = IllegalArgumentException("last")
+
+        try {
+            sendToFirstAvailableNode(listOf("preferred", "fallback")) {
+                if (it == "preferred") throw firstFailure else throw lastFailure
+            }
+            fail("Expected the final node failure")
+        } catch (t: Throwable) {
+            assertSame(lastFailure, t)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- broadcast the same already-signed transaction through the preferred node followed by the saved known-node list
- normalize and de-duplicate node URLs while preserving preferred-first order
- stop on the first non-empty transaction ID and preserve the last concrete node error when every attempt fails
- add focused JVM coverage for ordering, fallback, early stop, and all-nodes-failed behavior

Fixes #186.

## Verification

- `./gradlew :common-jvm:test` — 24 tests passed, 0 failures
- `git diff --check`

The repository currently pins `ergo-appkit_2.11:44fddd97-SNAPSHOT`, which is no longer available from its configured remote repositories. For the local test run I built and published that exact upstream commit to `mavenLocal`; no dependency change is included in this PR.
